### PR TITLE
Arrays and environment objects use indices into Vecs instead of Rc<RefCell<_>>

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -71,6 +71,43 @@ impl<T> EnvObjVecWrapper<T> {
     }
 }
 
+pub struct ArrayVecWrapper<T>(Vec<Vec<T>>);
+
+impl<T> Default for ArrayVecWrapper<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<T> Index<ArrayObjIdx> for ArrayVecWrapper<T> {
+    type Output = Vec<T>;
+
+    fn index(&self, index: ArrayObjIdx) -> &Self::Output {
+        if cfg!(debug_assertions) {
+            &self.0[index.0]
+        } else {
+            unsafe { self.0.get_unchecked(index.0) }
+        }
+    }
+}
+
+impl<T> IndexMut<ArrayObjIdx> for ArrayVecWrapper<T> {
+    fn index_mut(&mut self, index: ArrayObjIdx) -> &mut Self::Output {
+        if cfg!(debug_assertions) {
+            &mut self.0[index.0]
+        } else {
+            unsafe { self.0.get_unchecked_mut(index.0) }
+        }
+    }
+}
+
+impl<T> ArrayVecWrapper<T> {
+    pub fn add(&mut self, elem: Vec<T>) -> ArrayObjIdx {
+        self.0.push(elem);
+        ArrayObjIdx(self.0.len() - 1)
+    }
+}
+
 pub struct EnvironmentStore<T> {
     pub genv: EnvObj<T>,
     pub env_store: EnvObjVecWrapper<T>,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,8 +1,6 @@
 use crate::ast::{Exp, ScopeStmt, SlotStmt};
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ops::{Add, Div, Mul, Rem, Sub};
-use std::rc::Rc;
 use std::result;
 
 #[derive(Debug, PartialEq)]
@@ -22,13 +20,92 @@ pub type Result<T> = result::Result<T, InterpretError>;
 
 /// Interprets an AST of a program
 pub fn interpret(stmt: ScopeStmt) -> Result<()> {
-    stmt.eval(&mut EnvObj::new(None), &mut Obj::Null)?;
+    stmt.eval(&mut Default::default(), &mut Obj::Null)?;
     Ok(())
+}
+
+pub struct EnvironmentStore<T> {
+    pub genv: EnvObj<T>,
+    pub env_store: Vec<EnvObj<T>>,
+}
+
+impl<T> Default for EnvironmentStore<T> {
+    fn default() -> Self {
+        Self {
+            genv: Default::default(),
+            env_store: Default::default(),
+        }
+    }
+}
+
+impl<T: Clone> EnvironmentStore<T> {
+    pub fn from_table(globals: HashMap<String, T>) -> Self {
+        Self {
+            genv: EnvObj {
+                parent: None,
+                table: globals,
+            },
+            env_store: Default::default(),
+        }
+    }
+
+    pub fn add_env(&mut self, env_obj: EnvObj<T>) -> EnvObjIdx {
+        self.env_store.push(env_obj);
+        EnvObjIdx(self.env_store.len() - 1)
+    }
+
+    /// Retrieves an entry from the environment.
+    /// It first attempts to retrieve from the local environment and
+    /// if that fails then it attempts to retrieve from the global environment
+    pub fn get<'a>(&self, name: &str, env: &'a mut Obj) -> T {
+        let mut ent = None;
+        if let &mut Obj::Env(env_idx) = env {
+            ent = self.env_store[env_idx.0].get(&self.env_store, name);
+        }
+        if ent.is_none() {
+            ent = self.genv.get(&self.env_store, name);
+        }
+
+        ent.unwrap()
+    }
+
+    /// Sets an entry in the environment.
+    /// If the local environment already contains the entry, it sets the local environment,
+    /// otherwise it sets the global environment
+    pub fn set(&mut self, name: &str, entry: &T, env: &mut Obj) -> Result<()> {
+        let mut in_env = false;
+        if let Obj::Env(env_idx) = *env {
+            if self.env_store[env_idx.0].contains(&self.env_store, name) {
+                self.add(env_idx, name, entry);
+                in_env = true;
+            }
+        }
+
+        if !in_env {
+            // Only set if the object already contains the key
+            let _ = self.genv.get_result(&self.env_store, name)?;
+            self.genv.add(&mut self.env_store, name, entry.clone());
+        }
+
+        Ok(())
+    }
+
+    /// Adds key value pair to the environment at the given index.
+    pub fn add(&mut self, env_idx: EnvObjIdx, name: &str, entry: &T) {
+        let mut env_obj = std::mem::take(&mut self.env_store[env_idx.0]);
+        env_obj.add(&mut self.env_store, name, entry.clone());
+        self.env_store[env_idx.0] = env_obj;
+    }
+
+    /// Adds key value pair to global environment.
+    pub fn add_global(&mut self, name: &str, entry: &T) {
+        self.genv.add(&mut self.env_store, name, entry.clone());
+    }
 }
 
 impl Exp {
     /// Evaluates an expression given a local and global environment
-    pub fn eval(&self, genv: &mut EnvObj<Entry>, env: &mut Obj) -> Result<Obj> {
+    pub fn eval(&self, store: &mut EnvironmentStore<Entry>, env: &mut Obj) -> Result<Obj> {
         match *self {
             Exp::Int(i) => Ok(Obj::Int(IntObj { value: i })),
             Exp::Null => Ok(Obj::Null),
@@ -36,7 +113,7 @@ impl Exp {
                 let mut counter = 0;
                 for ch in printf.format.chars() {
                     if ch == '~' {
-                        let res = printf.exps[counter].eval(genv, env)?;
+                        let res = printf.exps[counter].eval(store, env)?;
                         print!("{}", res.int()?.value);
                         counter += 1;
                     } else {
@@ -46,42 +123,40 @@ impl Exp {
                 Ok(Obj::Null)
             }
             Exp::Array(ref array) => {
-                let length = array.length.eval(genv, env)?;
-                let init = array.init.eval(genv, env)?;
-                Ok(Obj::Array(Rc::new(RefCell::new(ArrayObj::new(
-                    length, init,
-                )?))))
+                let length = array.length.eval(store, env)?;
+                let init = array.init.eval(store, env)?;
+                Ok(Obj::Array(ArrayObj::new(length, init)?))
             }
             Exp::Object(ref obj) => {
-                let mut env_obj = Obj::Env(Rc::new(RefCell::new(make_env_obj(Some(
-                    obj.parent.eval(genv, env)?,
-                )))));
+                let new_env = make_env_obj(Some(obj.parent.eval(store, env)?));
+                let new_env_idx = store.add_env(new_env);
+                let mut env_obj = Obj::Env(new_env_idx);
                 for slot in &obj.slots {
-                    slot.exec(genv, env, &mut env_obj)?;
+                    slot.exec(store, env, &mut env_obj)?;
                 }
                 Ok(env_obj)
             }
             Exp::Slot(ref slot) => {
                 debug!("Getting slot: {}", &slot.name[..]);
-                let env_obj = slot.exp.eval(genv, env)?.env()?;
-                env_obj.borrow().get_result(&slot.name[..])?.var()
+                let env_idx = slot.exp.eval(store, env)?.env()?;
+                store.env_store[env_idx.0]
+                    .get_result(&store.env_store, &slot.name[..])?
+                    .var()
             }
             Exp::SetSlot(ref setslot) => {
                 debug!("Setting slot: {}", &setslot.name[..]);
-                let env_obj = setslot.exp.eval(genv, env)?.env()?;
-                let value = setslot.value.eval(genv, env)?;
-                env_obj
-                    .borrow_mut()
-                    .add(&setslot.name[..], Entry::Var(value));
+                let env_idx = setslot.exp.eval(store, env)?.env()?;
+                let value = setslot.value.eval(store, env)?;
+                store.add(env_idx, &setslot.name[..], &Entry::Var(value));
 
                 Ok(Obj::Null)
             }
             Exp::CallSlot(ref cs) => {
                 debug!("Calling slot: {}", &cs.name[..]);
-                let mut obj = cs.exp.eval(genv, env)?;
+                let mut obj = cs.exp.eval(store, env)?;
                 match obj {
                     Obj::Int(iexp) => {
-                        let other = cs.args[0].eval(genv, env)?.int()?;
+                        let other = cs.args[0].eval(store, env)?.int()?;
                         match &cs.name[..] {
                             "add" => Ok(Obj::Int(iexp + other)),
                             "sub" => Ok(Obj::Int(iexp - other)),
@@ -97,69 +172,80 @@ impl Exp {
                         }
                     }
                     Obj::Array(ref mut arr) => match &cs.name[..] {
-                        "length" => Ok(Obj::Int(arr.borrow().length())),
+                        "length" => Ok(Obj::Int(arr.length())),
                         "set" => {
-                            let name = cs.args[0].eval(genv, env)?;
-                            let param = cs.args[1].eval(genv, env)?;
-                            Ok(arr.borrow_mut().set(name, param)?)
+                            let name = cs.args[0].eval(store, env)?;
+                            let param = cs.args[1].eval(store, env)?;
+                            Ok(arr.set(name, param)?)
                         }
                         "get" => {
-                            let name = cs.args[0].eval(genv, env)?;
-                            Ok(arr.borrow().get(name)?.unwrap_or(Obj::Null))
+                            let name = cs.args[0].eval(store, env)?;
+                            Ok(arr.get(name)?.unwrap_or(Obj::Null))
                         }
                         _ => Err(InterpretError::InvalidSlot),
                     },
-                    Obj::Env(ref mut ent) => {
-                        let (fun, args) = ent.borrow().get_result(&cs.name[..])?.clone().func()?;
+                    Obj::Env(env_idx) => {
+                        let (fun, args) = store.env_store[env_idx.0]
+                            .get_result(&store.env_store, &cs.name[..])?
+                            .clone()
+                            .func()?;
                         if cs.nargs as usize != args.len() {
                             return Err(InterpretError::WrongArgsNum);
                         }
 
                         let mut new_env = EnvObj::new(None);
                         for (i, arg) in cs.args.iter().enumerate() {
-                            new_env.add(&args[i][..], Entry::Var(arg.eval(genv, env)?));
+                            let var_entry = Entry::Var(arg.eval(store, env)?);
+                            new_env.add(&mut store.env_store, &args[i][..], var_entry);
                         }
-                        new_env.add("this", Entry::Var(Obj::Env(ent.clone())));
+                        new_env.add(&mut store.env_store, "this", Entry::Var(Obj::Env(env_idx)));
 
-                        fun.eval(genv, &mut Obj::Env(Rc::new(RefCell::new(new_env))))
+                        let mut env_entry = Obj::Env(store.add_env(new_env));
+                        fun.eval(store, &mut env_entry)
                     }
                     _ => unreachable!(),
                 }
             }
             Exp::Call(ref call) => {
                 debug!("Calling function: {}", &call.name[..]);
-                let (fun, args) = genv.get_result(&call.name[..])?.clone().func()?;
+                let (fun, args) = store
+                    .genv
+                    .get_result(&store.env_store, &call.name[..])?
+                    .clone()
+                    .func()?;
                 if call.nargs as usize != args.len() {
                     return Err(InterpretError::WrongArgsNum);
                 }
 
                 let mut new_env = EnvObj::new(None);
                 for (i, arg) in call.args.iter().enumerate() {
-                    new_env.add(&args[i][..], Entry::Var(arg.eval(genv, env)?));
+                    let var_entry = Entry::Var(arg.eval(store, env)?);
+                    new_env.add(&mut store.env_store, &args[i][..], var_entry);
                 }
 
-                fun.eval(genv, &mut Obj::Env(Rc::new(RefCell::new(new_env))))
+                let new_env_idx = store.add_env(new_env);
+                fun.eval(store, &mut Obj::Env(new_env_idx))
             }
             Exp::Set(ref set) => {
-                let res = set.exp.eval(genv, env)?;
-                get_entry(&set.name[..], genv, env).var()?;
-                set_entry(&set.name, &Entry::Var(res), genv, env)?;
+                let res = set.exp.eval(store, env)?;
+                store.get(&set.name[..], env).var()?;
+                store.set(&set.name, &Entry::Var(res), env)?;
                 Ok(Obj::Null)
             }
             Exp::If(ref iexp) => {
-                let pred = iexp.pred.eval(genv, env)?;
+                let pred = iexp.pred.eval(store, env)?;
                 match pred {
-                    Obj::Null => iexp.alt.eval(genv, env),
-                    _ => iexp.conseq.eval(genv, env),
+                    Obj::Null => iexp.alt.eval(store, env),
+                    _ => iexp.conseq.eval(store, env),
                 }
             }
             Exp::While(ref wexp) => {
-                while let Obj::Int(_) = wexp.pred.eval(genv, env)? {
-                    wexp.body.eval(genv, env)?;
+                while let Obj::Int(_) = wexp.pred.eval(store, env)? {
+                    wexp.body.eval(store, env)?;
                 }
                 Ok(Obj::Null)
             }
-            Exp::Ref(ref name) => Ok(get_entry(name, genv, env).var()?.clone()),
+            Exp::Ref(ref name) => Ok(store.get(name, env).var()?.clone()),
         }
     }
 }
@@ -167,17 +253,23 @@ impl Exp {
 impl SlotStmt {
     /// Execute a slot statement given a local and global environment and
     /// the object that contains the slot
-    pub fn exec(&self, genv: &mut EnvObj<Entry>, env: &mut Obj, obj: &mut Obj) -> Result<()> {
-        let env_obj = obj.env_mut()?;
+    pub fn exec(
+        &self,
+        store: &mut EnvironmentStore<Entry>,
+        env: &mut Obj,
+        obj: &mut Obj,
+    ) -> Result<()> {
+        let env_idx = obj.env()?;
         match *self {
             SlotStmt::Var(ref var) => {
-                let var_exp = var.exp.eval(genv, env)?;
-                env_obj.borrow_mut().add(&var.name[..], Entry::Var(var_exp));
+                let var_exp = var.exp.eval(store, env)?;
+                store.add(env_idx, &var.name[..], &Entry::Var(var_exp));
             }
             SlotStmt::Method(ref met) => {
-                env_obj.borrow_mut().add(
+                store.add(
+                    env_idx,
                     &met.name[..],
-                    Entry::Func(met.body.clone(), met.args.clone()),
+                    &Entry::Func(met.body.clone(), met.args.clone()),
                 );
             }
         }
@@ -187,46 +279,47 @@ impl SlotStmt {
 
 impl ScopeStmt {
     /// Evaluates a scope statement given a local and global environment
-    pub fn eval(&self, genv: &mut EnvObj<Entry>, env: &mut Obj) -> Result<Obj> {
+    pub fn eval(&self, store: &mut EnvironmentStore<Entry>, env: &mut Obj) -> Result<Obj> {
         match *self {
             ScopeStmt::Var(ref var) => {
                 debug!("Var: {}", &var.name[..]);
-                let entry_obj = var.exp.eval(genv, env)?;
-                if let Obj::Env(ref mut env_obj) = *env {
-                    env_obj
-                        .borrow_mut()
-                        .add(&var.name[..], Entry::Var(entry_obj));
+                let entry_obj = var.exp.eval(store, env)?;
+                if let Obj::Env(env_idx) = *env {
+                    store.add(env_idx, &var.name[..], &Entry::Var(entry_obj));
                 } else {
-                    genv.add(&var.name[..], Entry::Var(entry_obj));
+                    store.add_global(&var.name[..], &Entry::Var(entry_obj));
                 }
                 Ok(Obj::Null)
             }
             ScopeStmt::Fn(ref fun) => {
                 debug!("Function: {}", &fun.name[..]);
-                genv.add(
+                store.add_global(
                     &fun.name[..],
-                    Entry::Func(fun.body.clone(), fun.args.clone()),
+                    &Entry::Func(fun.body.clone(), fun.args.clone()),
                 );
                 Ok(Obj::Null)
             }
             ScopeStmt::Seq(ref seq) => {
-                seq.a.eval(genv, env)?;
-                Ok(seq.b.eval(genv, env)?)
+                seq.a.eval(store, env)?;
+                Ok(seq.b.eval(store, env)?)
             }
-            ScopeStmt::Exp(ref exp) => Ok(exp.eval(genv, env)?),
+            ScopeStmt::Exp(ref exp) => Ok(exp.eval(store, env)?),
         }
     }
 }
 
-pub type EnvObjRef<T> = Rc<RefCell<EnvObj<T>>>;
+/// A wrapper around an index into a Vec of environment
+/// objects.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EnvObjIdx(pub usize);
 
 /// An object used by the interpreter
 #[derive(Clone, Debug, PartialEq)]
 pub enum Obj {
     Null,
     Int(IntObj),
-    Array(Rc<RefCell<ArrayObj>>),
-    Env(EnvObjRef<Entry>),
+    Array(ArrayObj),
+    Env(EnvObjIdx),
 }
 
 impl Obj {
@@ -269,7 +362,7 @@ impl Obj {
 
     /// Returns the unwrapped array object as a Result<>
     #[inline]
-    pub fn array(self) -> Result<Rc<RefCell<ArrayObj>>> {
+    pub fn array(self) -> Result<ArrayObj> {
         match self {
             Obj::Array(arr) => Ok(arr),
             _ => Err(InterpretError::ObjShouldBeArray),
@@ -278,18 +371,9 @@ impl Obj {
 
     /// Returns the unwrapped environment object as a Result<>
     #[inline]
-    pub fn env(self) -> Result<EnvObjRef<Entry>> {
+    pub fn env(&self) -> Result<EnvObjIdx> {
         match self {
-            Obj::Env(e) => Ok(e),
-            _ => Err(InterpretError::ObjShouldBeObject),
-        }
-    }
-
-    /// Returns a mutable reference to the unwrapped environment object as a Result<>
-    #[inline]
-    pub fn env_mut(&mut self) -> Result<&mut EnvObjRef<Entry>> {
-        match *self {
-            Obj::Env(ref mut e) => Ok(e),
+            Obj::Env(e) => Ok(*e),
             _ => Err(InterpretError::ObjShouldBeObject),
         }
     }
@@ -420,44 +504,49 @@ impl Entry {
 /// for prototypical inheritance (like Javascript)
 #[derive(Clone, Debug, PartialEq)]
 pub struct EnvObj<T> {
-    parent: Option<Box<EnvObjRef<T>>>,
+    parent: Option<EnvObjIdx>,
     table: HashMap<String, T>,
 }
 
-impl<T: Clone + PartialEq> EnvObj<T> {
+impl<T> Default for EnvObj<T> {
+    fn default() -> Self {
+        Self {
+            parent: Default::default(),
+            table: Default::default(),
+        }
+    }
+}
+
+impl<T: Clone> EnvObj<T> {
     /// Creates a new environment object given a parent object
-    pub fn new(parent: Option<EnvObjRef<T>>) -> EnvObj<T> {
+    pub fn new(parent: Option<EnvObjIdx>) -> EnvObj<T> {
         EnvObj {
-            parent: parent.map(Box::new),
+            parent,
             table: HashMap::new(),
         }
     }
 
     /// Adds a new entry to the environment object
-    pub fn add(&mut self, name: &str, entry: T) {
-        if !self.add_parent(name, &entry) {
+    pub fn add(&mut self, env_store: &mut Vec<EnvObj<T>>, name: &str, entry: T) {
+        if !self.add_parent(env_store, name, &entry) {
             self.table.insert(name.to_owned(), entry);
         }
     }
 
     /// Retrieves an entry from the environment object
-    pub fn get(&self, name: &str) -> Option<T> {
+    pub fn get(&self, env_store: &Vec<EnvObj<T>>, name: &str) -> Option<T> {
         if let Some(data) = self.table.get(name) {
             return Some(data.clone());
         }
 
-        let mut parent_env = self.parent.clone();
+        let mut parent_env = self.parent;
 
-        while let Some(env) = parent_env.take() {
-            if let Some(data) = env.borrow().get(name) {
+        while let Some(env_idx) = parent_env {
+            if let Some(data) = env_store[env_idx.0].get(env_store, name) {
                 return Some(data.clone());
             }
 
-            if let Some(ref parent) = env.borrow().parent {
-                parent_env = Some(parent.clone());
-            } else {
-                break;
-            }
+            parent_env = env_store[env_idx.0].parent;
         }
 
         None
@@ -465,8 +554,8 @@ impl<T: Clone + PartialEq> EnvObj<T> {
 
     /// Same as get() but returns a Result<> instead of an Option<>
     #[inline]
-    pub fn get_result(&self, name: &str) -> Result<T> {
-        match self.get(name) {
+    pub fn get_result(&self, env_store: &Vec<EnvObj<T>>, name: &str) -> Result<T> {
+        match self.get(env_store, name) {
             Some(item) => Ok(item),
             None => Err(InterpretError::CannotFind(name.to_string())),
         }
@@ -474,42 +563,38 @@ impl<T: Clone + PartialEq> EnvObj<T> {
 
     /// Returns true if the object contains an entry with the given key,
     /// false otherwise
-    pub fn contains(&self, name: &str) -> bool {
-        self.get(name).is_some()
+    pub fn contains(&self, env_store: &Vec<EnvObj<T>>, name: &str) -> bool {
+        self.get(env_store, name).is_some()
     }
 
     /// Attempts to traverse up the parents looking for
     /// the first parent that contains the name
     /// and adds and sets the entry to that parent object.
     /// Returns whether the attempt was successful
-    fn add_parent(&mut self, name: &str, entry: &T) -> bool {
+    fn add_parent(&mut self, env_store: &mut Vec<EnvObj<T>>, name: &str, entry: &T) -> bool {
         if self.table.contains_key(name) {
             self.table.insert(name.to_owned(), entry.clone());
             return true;
         }
 
         let mut target_env = None;
-        let mut parent_env = self.parent.clone();
+        let mut parent_env = self.parent;
 
-        while let Some(env) = parent_env.take() {
+        while let Some(env_idx) = parent_env {
             let mut has_target_env = false;
-            if env.borrow().table.contains_key(name) {
+            if env_store[env_idx.0].table.contains_key(name) {
                 has_target_env = true;
             }
             if has_target_env {
-                target_env = Some(env);
+                target_env = Some(env_idx);
                 break;
             }
 
-            if let Some(ref mut parent) = env.borrow_mut().parent {
-                parent_env = Some(parent.clone());
-            } else {
-                break;
-            }
+            parent_env = env_store[env_idx.0].parent;
         }
 
-        if let Some(ref mut env) = target_env {
-            env.borrow_mut()
+        if let Some(env_idx) = target_env {
+            env_store[env_idx.0]
                 .table
                 .insert(name.to_owned(), entry.clone());
             true
@@ -526,42 +611,6 @@ fn make_env_obj(parent: Option<Obj>) -> EnvObj<Entry> {
         Some(Obj::Null) => EnvObj::new(None),
         _ => panic!("{:?} not an environment object or null", parent),
     }
-}
-
-/// Retrieves an entry from the environment.
-/// It first attempts to retrieve from the local environment and
-/// if that fails then it attempts to retrieve from the global environment
-fn get_entry<'a>(name: &str, genv: &'a mut EnvObj<Entry>, env: &'a mut Obj) -> Entry {
-    let mut ent = None;
-    if let &mut Obj::Env(ref mut env) = env {
-        ent = env.borrow().get(name);
-    }
-    if ent.is_none() {
-        ent = genv.get(name);
-    }
-
-    ent.unwrap()
-}
-
-/// Sets an entry in the environment.
-/// If the local environment already contains the entry, it sets the local environment,
-/// otherwise it sets the global environment
-fn set_entry(name: &str, entry: &Entry, genv: &mut EnvObj<Entry>, env: &mut Obj) -> Result<()> {
-    let mut in_env = false;
-    if let &mut Obj::Env(ref mut env) = env {
-        if env.borrow().contains(name) {
-            env.borrow_mut().add(name, entry.clone());
-            in_env = true;
-        }
-    }
-
-    if !in_env {
-        // Only set if the object already contains the key
-        let _ = genv.get_result(name)?;
-        genv.add(name, entry.clone());
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -148,7 +148,7 @@ impl<T: Clone> EnvironmentStore<T> {
     /// Retrieves an entry from the environment.
     /// It first attempts to retrieve from the local environment and
     /// if that fails then it attempts to retrieve from the global environment
-    pub fn get<'a>(&self, name: &str, env: &'a mut Obj) -> T {
+    pub fn get(&self, name: &str, env: &mut Obj) -> T {
         let mut ent = None;
         if let &mut Obj::Env(env_idx) = env {
             ent = self.env_store[env_idx].get(&self.env_store, name);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -251,9 +251,7 @@ impl VM {
             Inst::GetSlot(name) => {
                 let name = get_str_val!(name, program, "GetSlot");
                 if let Some(Obj::EnvObj(env_idx)) = vm.operand.pop() {
-                    if let Some(val) =
-                        vm.store.env_store[env_idx.0].get(&vm.store.env_store, &name[..])
-                    {
+                    if let Some(val) = vm.store[env_idx].get(&vm.store.env_store, &name[..]) {
                         vm.operand.push(val);
                     }
                 } else {
@@ -334,14 +332,13 @@ impl VM {
                     }
                     Some(Obj::EnvObj(env_idx)) => {
                         debug!("Object slot: {:?}", name);
-                        let (code, nslots) = match vm.store.env_store[env_idx.0]
-                            .get(&vm.store.env_store, &name[..])
-                        {
-                            Some(Obj::Method(m)) => {
-                                (m.code.clone(), m.nargs as usize + m.nlocals as usize + 1)
-                            }
-                            _ => return Err(Error::new(InvalidData, "CallSlot: Invalid name")),
-                        };
+                        let (code, nslots) =
+                            match vm.store[env_idx].get(&vm.store.env_store, &name[..]) {
+                                Some(Obj::Method(m)) => {
+                                    (m.code.clone(), m.nargs as usize + m.nlocals as usize + 1)
+                                }
+                                _ => return Err(Error::new(InvalidData, "CallSlot: Invalid name")),
+                            };
 
                         let mut slots = vec![Obj::Null; nslots];
                         // Slot 0 in the new local frame holds the receiver object

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,12 +1,10 @@
 use crate::bytecode::{Inst, MethodValue, Program, Value};
-use crate::interpreter::{EnvObj, EnvObjRef};
-use std::cell::RefCell;
+use crate::interpreter::{EnvObj, EnvObjIdx, EnvironmentStore};
 use std::collections::HashMap;
 use std::io;
 use std::io::Error;
 use std::io::ErrorKind::*;
 use std::mem;
-use std::rc::Rc;
 
 /// Interprets the bytecode structure
 pub fn interpret_bc(program: Program) -> io::Result<()> {
@@ -38,9 +36,9 @@ pub enum EvalResult {
 pub enum Obj {
     Int(i32),
     Null,
-    Array(Rc<RefCell<Vec<Obj>>>),
+    Array(Vec<Obj>),
     Method(MethodValue),
-    EnvObj(EnvObjRef<Obj>),
+    EnvObj(EnvObjIdx),
 }
 
 impl Obj {
@@ -93,8 +91,8 @@ impl Frame {
 pub const VM_CAPACITY: usize = 13;
 
 pub struct VM {
-    // Global variable and label name-to-value maps
-    global_vars: HashMap<String, Obj>,
+    // Variable and label name-to-value maps
+    store: EnvironmentStore<Obj>,
     labels: HashMap<String, LabelAddr>,
 
     code: Vec<Inst>,
@@ -164,7 +162,7 @@ impl VM {
         }
 
         Ok(VM {
-            global_vars,
+            store: EnvironmentStore::from_table(global_vars),
             labels,
             code,
             pc: 0,
@@ -185,8 +183,7 @@ impl VM {
             },
             Inst::Array => {
                 if let (Some(init), Some(Obj::Int(len))) = (vm.operand.pop(), vm.operand.pop()) {
-                    vm.operand
-                        .push(Obj::Array(Rc::new(RefCell::new(vec![init; len as usize]))));
+                    vm.operand.push(Obj::Array(vec![init; len as usize]));
                 } else {
                     return Err(Error::new(InvalidData, "Invalid length type for ARRAY"));
                 }
@@ -236,25 +233,27 @@ impl VM {
                         match program.values.get(*slot as usize) {
                             Some(Value::Method(m)) => {
                                 let name = get_str_val!(m.name, program, "Object");
-                                obj.add(&name[..], Obj::Method(m.clone()));
+                                obj.add(&mut vm.store.env_store, &name[..], Obj::Method(m.clone()));
                             }
                             Some(&Value::Slot(name)) => {
                                 let name = get_str_val!(name, program, "Object");
-                                obj.add(&name[..], args.next().unwrap());
+                                obj.add(&mut vm.store.env_store, &name[..], args.next().unwrap());
                             }
                             _ => {}
                         }
                     }
 
-                    operand.push(Obj::EnvObj(Rc::new(RefCell::new(obj))));
+                    operand.push(Obj::EnvObj(vm.store.add_env(obj)));
                 } else {
                     return Err(Error::new(InvalidInput, "Object: Invalid index"));
                 }
             }
             Inst::GetSlot(name) => {
                 let name = get_str_val!(name, program, "GetSlot");
-                if let Some(Obj::EnvObj(ref obj)) = vm.operand.pop() {
-                    if let Some(val) = obj.borrow().get(&name[..]) {
+                if let Some(Obj::EnvObj(env_idx)) = vm.operand.pop() {
+                    if let Some(val) =
+                        vm.store.env_store[env_idx.0].get(&vm.store.env_store, &name[..])
+                    {
                         vm.operand.push(val);
                     }
                 } else {
@@ -263,9 +262,10 @@ impl VM {
             }
             Inst::SetSlot(name) => {
                 let name = get_str_val!(name, program, "SetSlot");
-                if let (Some(value), Some(Obj::EnvObj(obj))) = (vm.operand.pop(), vm.operand.pop())
+                if let (Some(value), Some(Obj::EnvObj(env_idx))) =
+                    (vm.operand.pop(), vm.operand.pop())
                 {
-                    obj.borrow_mut().add(&name[..], value.clone());
+                    vm.store.add(env_idx, &name[..], &value);
                     vm.operand.push(value);
                 } else {
                     return Err(Error::new(InvalidData, "SetSlot: Not object type"));
@@ -303,10 +303,10 @@ impl VM {
                             _ => return Err(Error::new(InvalidData, "CallSlot: Invalid operator")),
                         });
                     }
-                    Some(Obj::Array(arr)) => {
+                    Some(Obj::Array(mut arr)) => {
                         debug!("Array slot: {:?} for {:?}", name, arr);
                         match &name[..] {
-                            "length" => operand.push(Obj::Int(arr.borrow().len() as i32)),
+                            "length" => operand.push(Obj::Int(arr.len() as i32)),
                             "set" => {
                                 if num != 3 {
                                     return inval_err("CallSlot", "Arity must be 3");
@@ -316,7 +316,7 @@ impl VM {
                                     Obj::Int(i) => i as usize,
                                     _ => return inval_err("CallSlot", "Set index not int"),
                                 };
-                                arr.borrow_mut()[index] = data;
+                                arr[index] = data;
                                 operand.push(Obj::Null);
                             }
                             "get" => {
@@ -327,14 +327,16 @@ impl VM {
                                     Obj::Int(i) => i as usize,
                                     _ => return inval_err("CallSlot", "Set index not int"),
                                 };
-                                operand.push(arr.borrow()[index].clone());
+                                operand.push(arr[index].clone());
                             }
                             _ => return Err(Error::new(InvalidData, "CallSlot: Invalid name")),
                         }
                     }
-                    Some(Obj::EnvObj(obj)) => {
+                    Some(Obj::EnvObj(env_idx)) => {
                         debug!("Object slot: {:?}", name);
-                        let (code, nslots) = match obj.borrow().get(&name[..]) {
+                        let (code, nslots) = match vm.store.env_store[env_idx.0]
+                            .get(&vm.store.env_store, &name[..])
+                        {
                             Some(Obj::Method(m)) => {
                                 (m.code.clone(), m.nargs as usize + m.nlocals as usize + 1)
                             }
@@ -344,7 +346,7 @@ impl VM {
                         let mut slots = vec![Obj::Null; nslots];
                         // Slot 0 in the new local frame holds the receiver object
                         // Following slots hold argument values from last-popped to first-popped
-                        slots[0] = Obj::EnvObj(obj);
+                        slots[0] = Obj::EnvObj(env_idx);
                         args.into_iter().rev().fold(1, |index, arg| {
                             slots[index] = arg;
                             index + 1
@@ -387,11 +389,11 @@ impl VM {
                     None => return Err(Error::new(InvalidData, "SetGlobal: Op Stack empty")),
                 };
 
-                vm.global_vars.insert(name, value);
+                vm.store.add_global(&name, &value);
             }
             Inst::GetGlobal(name) => {
                 let name = get_str_val!(name, program, "GetGlobal");
-                let value = match vm.global_vars.get(&name) {
+                let value = match vm.store.genv.get(&vm.store.env_store, &name) {
                     Some(v) => v.clone(),
                     None => return Err(Error::new(InvalidData, "GetGlobal: Invalid name")),
                 };
@@ -429,11 +431,12 @@ impl VM {
                 let operand = &mut vm.operand;
                 let args: Vec<_> = (0..num).flat_map(|_| operand.pop()).collect();
                 let name = get_str_val!(name, program, "Call");
-                let (code, nslots) = if let Some(Obj::Method(m)) = vm.global_vars.get(&name) {
-                    (m.code.clone(), m.nargs as usize + m.nlocals as usize)
-                } else {
-                    return Err(Error::new(InvalidData, "Call: Invalid method type"));
-                };
+                let (code, nslots) =
+                    if let Some(Obj::Method(m)) = vm.store.genv.get(&vm.store.env_store, &name) {
+                        (m.code.clone(), m.nargs as usize + m.nlocals as usize)
+                    } else {
+                        return Err(Error::new(InvalidData, "Call: Invalid method type"));
+                    };
 
                 let mut slots = vec![Obj::Null; nslots];
                 // Populate slots with the argument values from


### PR DESCRIPTION
Normally, arrays and environment objects allocated by feeny are not supposed to be reference counted. That allows you to write a garbage collector in the next section in order to free memory. However, when I started this project I couldn't get the code to compile without using `Rc<RefCell<_>>` because of the complicated lifetimes of these objects.

The way to do this in Rust is to have the references be indices into `Vec`s instead of pointers. This PR implements this and removes uses of `Rc` and `RefCell`. It creates newtype wrappers around the indexes into the array and environment object stores and allows for unsafe indexing in release mode, which should be safe because you can only acquire an index type safely from adding to the Vec.

Using `Rc<RefCell<_>>` is actually a better idea if we don't want to implement a garbage collector though. After doing some casual benchmarking, it seems that the indices into `Vec` method isn't noticeably faster than the `Rc<RefCell<_>>` method, and the `Rc<RefCell<_>>` method allows for objects to be cleaned up when there are no more references to them. Because of this, I will leave this PR open just to show how to do it with the indices into `Vec` way. 